### PR TITLE
Add CSRF exempt authentication to the batch_completion api

### DIFF
--- a/completion/api/authentication.py
+++ b/completion/api/authentication.py
@@ -1,0 +1,12 @@
+"""
+Authentication classes for the API.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework.authentication import SessionAuthentication
+
+
+class CsrfExemptSessionAuthentication(SessionAuthentication):
+
+    def enforce_csrf(self, request):
+        return  # To not perform the csrf check previously happening

--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.utils.translation import ugettext as _
 from django.db import DatabaseError
 
+from rest_framework.authentication import BasicAuthentication
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import permissions
@@ -26,6 +27,7 @@ except ImportError:
 
 from completion import waffle
 from completion.api.permissions import IsStaffOrOwner, IsUserInUrl
+from completion.api.authentication import CsrfExemptSessionAuthentication
 from completion.models import BlockCompletion
 
 
@@ -33,6 +35,7 @@ class CompletionBatchView(APIView):
     """
     Handles API requests to submit batch completions.
     """
+    authentication_classes = (CsrfExemptSessionAuthentication, BasicAuthentication)
     permission_classes = (permissions.IsAuthenticated, IsStaffOrOwner,)
     REQUIRED_KEYS = ['username', 'course_key', 'blocks']
 


### PR DESCRIPTION
**Description:** The PR adds CSRF capability to the Completion_Batch api

**JIRA:** https://openedx.atlassian.net/browse/LEARNER-5542

**Dependencies:** Need edx-platform to incorporate this.

**Installation instructions:** Need to have a version pump for edx-platform

**Testing instructions:** API post to completion_batch endpoint without CSRF token

**Reviewers:**
- [ ] @iloveagent57 
- [ ] @saeedbashir 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
