### PR TITLE
chore: bump version for next release

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '4.1.0'
+__version__ = '4.2.0'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This PR bumps the version for next release as a part of this [PR](https://github.com/openedx/completion/pull/180) that drops support for Django22, 30 and 31