### PR TITLE
fix: manually update pip-tools to avoid incompatibility issue

### DIFF
--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.0
     # via -r requirements/pip-tools.in
 tomli==2.0.0
     # via pep517


### PR DESCRIPTION
Manually update the `pip-tools.txt` generated file to fix an issue with pip and pip-tools. `Pip` 22.x and `pip-tools` <6.5 are not compatible with each other. Normally, we shouldn't modify a generated file but we are stuck without doing it this time.
