### PR TITLE
fix: transfer ownership from engage to cosmonauts

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Requirements
 
 on:
   schedule:
-     - cron: "15 0 * * 5"
+     - cron: "15 15 10,24 * *"
   workflow_dispatch:
      inputs:
        branch:
@@ -13,9 +13,11 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "engage-squad"
-       email_address: engage-squad-eng@edx.org
-       send_success_notification: false
+       # optional parameters below; fill in if you'd like github or email notifications
+       # user_reviewers: ""
+       # team_reviewers: ""
+       email_address: "cosmonauts-requirements-update@2u-internal.opsgenie.net"
+       send_success_notification: true
     secrets:
        requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
Repository is no longer owned by engage, so notifications should be rerouted to cosmonauts.