### PR TITLE
fix: upgrade pip-tools to fix bug in versions 6.6.0 and 6.6.1

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -165,7 +165,7 @@ pbr==5.9.0
     # via stevedore
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/dev.in
 pkginfo==1.8.2
     # via twine

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
Version 6.6.0 and 6.6.1 of pip-tools contain bugs that break the python requirements update Github action. The bugs have been reported: 
* https://github.com/jazzband/pip-tools/issues/1617
* https://github.com/jazzband/pip-tools/pull/1624

Version 6.6.2 contains the fix for both of these bugs, and this upgrade has happened in other repositories (see https://github.com/openedx/edx-bulk-grades/pull/120).

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
