### PR TITLE
chore: Switch from edx-sphinx-theme to sphinx-book-theme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
+  deprecated
+
 [4.1.0]- 2021-07-19
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Add Django 3.0, 3.1 & 3.2 Support

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,13 +16,59 @@ serve to show the default.
 import os
 import re
 import sys
+from datetime import datetime
 from subprocess import check_call
-
-import edx_theme
 
 import django
 from django.conf import settings
 
+
+html_theme_options = {
+    "repository_url": "https://github.com/openedx/completion",
+    "repository_branch": "master",
+    "path_to_docs": "docs/",
+    "home_page_in_toc": True,
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+    # Please don't change unless you know what you're doing.
+    "extra_footer": """
+        <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">
+            <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png"/>
+        </a>
+        <br>
+        These works by
+            <a
+                xmlns:cc="https://creativecommons.org/ns#"
+                href="https://openedx.org"
+                property="cc:attributionName"
+                rel="cc:attributionURL"
+            >Axim Collaborative, Inc</a>
+        are licensed under a
+            <a
+                rel="license"
+                href="https://creativecommons.org/licenses/by-sa/4.0/"
+            >Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+    """
+}
+
+# Note the logo won't show up properly yet because there is an upstream
+# bug in the theme that needs to be fixed first.
+# If you'd like you can temporarily copy the logo file to your `_static`
+# directory.
+html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
+html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
+
+# Set the DJANGO_SETTINGS_MODULE if it's not set.
+# Only if your project has a dependency on Django
+if not os.environ.get('DJANGO_SETTINGS_MODULE'):
+   # If you do depend on django you'll need a settings file that you can
+   # use when building docs.  This will allow you to pull docstrings from
+   # your code.
+   os.environ['DJANGO_SETTINGS_MODULE'] = 'completion.settings.test_settings'
 
 def get_version(*file_paths):
     """
@@ -62,7 +108,6 @@ django.setup()
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'edx_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -93,8 +138,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'completion'
-copyright = edx_theme.COPYRIGHT  # pylint: disable=redefined-builtin
-author = edx_theme.AUTHOR
+copyright = f'{datetime.now().year}, Axim Collaborative, Inc'
+author = 'Axim Collaborative, Inc'
 project_title = 'completion'
 documentation_title = f"{project_title}"
 
@@ -165,7 +210,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'edx_theme'
+html_theme = "sphinx_book_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -174,8 +219,8 @@ html_theme = 'edx_theme'
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [edx_theme.get_html_theme_path()]
-
+# html_theme_path = [edx_theme.get_html_theme_path()]
+#
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
 #

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -5,5 +5,5 @@
 -r test.in                # Test requirements to allow imports during API doc generation
 
 doc8                      # reStructuredText style checker
-edx_sphinx_theme          # edX theme for Sphinx output
+sphinx-book-theme
 Sphinx                    # Documentation builder

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+accessible-pygments==0.0.4
+    # via pydata-sphinx-theme
 alabaster==0.7.13
     # via sphinx
 appdirs==1.4.4
@@ -11,7 +13,11 @@ appdirs==1.4.4
 asgiref==3.6.0
     # via django
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
@@ -64,6 +70,7 @@ doc8==1.1.1
 docutils==0.19
     # via
     #   doc8
+    #   pydata-sphinx-theme
     #   restructuredtext-lint
     #   sphinx
 drf-jwt==1.19.2
@@ -78,8 +85,6 @@ edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 edx-toggles==5.0.0
     # via -r requirements/base.in
 exceptiongroup==1.1.1
@@ -118,6 +123,7 @@ newrelic==8.8.0
     # via edx-django-utils
 packaging==23.1
     # via
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
 pbr==5.11.1
@@ -130,9 +136,13 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.17
     # via pyjwkest
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.0
     # via
+    #   accessible-pygments
     #   doc8
+    #   pydata-sphinx-theme
     #   sphinx
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -183,16 +193,20 @@ semantic-version==2.10.0
 six==1.16.0
     # via
     #   edx-drf-extensions
-    #   edx-sphinx-theme
     #   fs
     #   pyjwkest
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.4.1
+    # via beautifulsoup4
 sphinx==5.3.0
     # via
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -220,6 +234,8 @@ tomli==2.0.1
     #   coverage
     #   doc8
     #   pytest
+typing-extensions==4.5.0
+    # via pydata-sphinx-theme
 urllib3==1.26.15
     # via requests
 web-fragments==2.0.0


### PR DESCRIPTION
The edx-sphinx theme is being deprecated, and replaced with sphinx-book-theme. This removes references to the deprecated theme and replaces them with the new standard theme for the platform.

**Testing instructions:** 
- Run `make docs` and see that the docs are generated properly and use the sphinx-book-theme

**Reviewers:**

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
