### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,8 @@ How To Contribute
 
 Contributions are very welcome.
 
-Please read `How To Contribute <https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst>`_ for details.
+Please read `How To Contribute <https://github.com/openedx/.github/blob/master/CONTRIBUTING.md>`_ for details.
 
-Even though they were written with ``edx-platform`` in mind, the guidelines
-should be followed for Open edX code in general.
 
 PR description template should be automatically applied if you are sending PR from github interface; otherwise you
 can find it it at `PULL_REQUEST_TEMPLATE.md <https://github.com/openedx/completion/blob/master/.github/PULL_REQUEST_TEMPLATE.md>`_


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
