### PR TITLE
refactor: support `get_child_blocks` along with `get_child_descriptors`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.2.1]- 2023-04-26
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Support ``get_child_blocks`` along with ``get_child_descriptors``.
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '4.2.0'
+__version__ = '4.2.1'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/services.py
+++ b/completion/services.py
@@ -93,7 +93,9 @@ class CompletionService:
         user_children = []
         mode = XBlockCompletionMode.get_mode(node)
         if mode == XBlockCompletionMode.AGGREGATOR:
+            # TODO: `get_child_descriptors` will be renamed to `get_child_blocks` in the Redwood release.
             node_children = ((hasattr(node, 'get_child_descriptors') and node.get_child_descriptors())
+                             or (hasattr(node, 'get_child_blocks') and node.get_child_blocks())
                              or (hasattr(node, 'get_children') and node.get_children()))
             for child in node_children:
                 user_children.extend(self.get_completable_children(child))


### PR DESCRIPTION
**Description:** This method will be renamed in the Redwood release.

**Dependencies:** This is required to support changes from https://github.com/openedx/edx-platform/pull/31492.

**Testing instructions:** See that the tests from https://github.com/openedx/edx-platform/pull/31492 are passing.

**Reviewers:**
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings): n/a
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
