### PR TITLE
chore: update requirements upgrade schedule to match other repos

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Requirements
 
 on:
   schedule:
-     - cron: "15 15 10,24 * *"
+     - cron: "15 15 * * 2"
   workflow_dispatch:
      inputs:
        branch:


### PR DESCRIPTION
**Description:** Other repositories owned by the Cosmonauts team have a scheduled python requirements upgrade to run every Tuesday. This repository should be updated to match our current schedule.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
