### PR TITLE
fix: do not define django_app_config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.4.1] - 2023-10-27
+~~~~~~~~~~~~~~~~~~~~
+* Fix RemovedInDjango41Warning by removing `django_app_config`
+
 [4.4.0] - 2023-10-20
 ~~~~~~~~~~~~~~~~~~~~
 * Added tracking logs for completion events

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,5 @@
 Completion App
 """
 
-__version__ = '4.4.0'
 
-default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name
+__version__ = '4.4.1'


### PR DESCRIPTION
**Description:** 

Newer django versions throw the following warning: `RemovedInDjango41Warning: 'completion' defines default_app_config = 'completion.apps.CompletionAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.`, and it clutters edx-platform logs. This PR avoids defining it when django.VERSION < 3.2

**Related issue:** https://github.com/openedx/edx-platform/issues/33572

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**
- create and activate a virtual environment using python 3.8.17
- run `make install`
- run  `pytest -k "DefaultAppConfig" --no-cov -v`and make sure `test_not_defined` passes

**Reviewers:**
- [ ] @Agrendalath
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
