### PR TITLE
feat: handle optional blocks in verticals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.5.0] - 2024-02-26
+~~~~~~~~~~~~~~~~~~~~
+* Ignore optional blocks in non-optional verticals
+
 [4.4.1] - 2023-10-27
 ~~~~~~~~~~~~~~~~~~~~
 * Fix RemovedInDjango41Warning by removing `django_app_config`

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -3,4 +3,4 @@ Completion App
 """
 
 
-__version__ = '4.4.1'
+__version__ = '4.5.0'

--- a/completion/services.py
+++ b/completion/services.py
@@ -117,13 +117,14 @@ class CompletionService:
         if not self.completion_tracking_enabled():
             return None
 
-        optional_vertical = getattr(item, "optional_content", False)
+        optional_vertical = getattr(item, "optional_completion", False)
 
         # this is temporary local logic and will be removed when the whole course tree is included in completion
         child_locations = [
             child.scope_ids.usage_id for child in self.get_completable_children(item)
-            # for non-optional verticals, only include non-optional children
-            if optional_vertical or not getattr(child, "optional_content", False)
+            # if vertical is optional, include all children
+            # else only include non-optional children
+            if optional_vertical or not getattr(child, "optional_completion", False)
         ]
         completions = self.get_completions(child_locations)
         for child_location in child_locations:

--- a/completion/services.py
+++ b/completion/services.py
@@ -117,8 +117,14 @@ class CompletionService:
         if not self.completion_tracking_enabled():
             return None
 
+        optional_vertical = getattr(item, "optional_content", False)
+
         # this is temporary local logic and will be removed when the whole course tree is included in completion
-        child_locations = [child.scope_ids.usage_id for child in self.get_completable_children(item)]
+        child_locations = [
+            child.scope_ids.usage_id for child in self.get_completable_children(item)
+            # for non-optional verticals, only include non-optional children
+            if optional_vertical or not getattr(child, "optional_content", False)
+        ]
         completions = self.get_completions(child_locations)
         for child_location in child_locations:
             if completions[child_location] < 1.0:

--- a/completion/services.py
+++ b/completion/services.py
@@ -108,6 +108,9 @@ class CompletionService:
         """
         Checks if child should count towards a vertical's completion.
 
+        This is done by comparing the "optional_completion" values of the vertical
+        and the child. Here optional completion means that the completion of a child
+        doesn't count towards the completion of a parent for the purposes of this library.
         There are only four combinations:
         1. Optional Vertical and Optional Child -> Include Child
         2. Optional Vertical and Required Child -> Include Child

--- a/completion/tests/test_services.py
+++ b/completion/tests/test_services.py
@@ -205,19 +205,20 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
             []
         )
 
-    def test_matches_vertical_optional_completion(self):
-        for optional_vertical, optional_child, should_include_child in (
-            (True, True, True),
-            (True, False, True),
-            (False, False, True),
-            (False, True, False),  # do not count optional children for non-optional verticals
-        ):
-            self.assertEqual(
-                self.completion_service.matches_vertical_optional_completion(
-                    optional_vertical, optional_child
-                ),
-                should_include_child,
-            )
+    @ddt.data(
+        (True, True, True),
+        (True, False, True),
+        (False, False, True),
+        (False, True, False),  # do not count optional children for non-optional verticals
+    )
+    @ddt.unpack
+    def test_matches_vertical_optional_completion(self, optional_vertical, optional_child, should_include_child):
+        self.assertEqual(
+            self.completion_service.matches_vertical_optional_completion(
+                optional_vertical, optional_child
+            ),
+            should_include_child,
+        )
 
 
 @ddt.ddt

--- a/completion/tests/test_services.py
+++ b/completion/tests/test_services.py
@@ -205,6 +205,20 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
             []
         )
 
+    def test_matches_vertical_optional_completion(self):
+        for optional_vertical, optional_child, should_include_child in (
+            (True, True, True),
+            (True, False, True),
+            (False, False, True),
+            (False, True, False),  # do not count optional children for non-optional verticals
+        ):
+            self.assertEqual(
+                self.completion_service.matches_vertical_optional_completion(
+                    optional_vertical, optional_child
+                ),
+                should_include_child,
+            )
+
 
 @ddt.ddt
 class CompletionDelayTestCase(CompletionSetUpMixin, TestCase):


### PR DESCRIPTION
**Note:** Not sure how to increase coverage since there's no testing in place for 

**Description:** handles not counting optional children for non-optional verticals

**Dependencies:** 
https://github.com/open-craft/edx-platform/pull/638

**Testing instructions:**

- Using this branch and https://github.com/openedx/edx-platform/pull/34275/
- Create a sequence with a single optional unit and a non-optional unit
  * You can set them as optional in the settings for the unit in the content outline in studio
- Finish only the non-optional unit
- Make sure the sequence gets marked as done

**Reviewers:**
- [x] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
