### PR TITLE
fix: Remove trailing comma that caused catalog-in fo.yaml to be invalid yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "A library for tracking completion of blocks by learners in edX courses."
   links:
     - url: "https://github.com/openedx/completion"
-      title: "Block Completion API",
+      title: "Block Completion API"
       icon: "Web"
 spec:
   owner: group:committers-completion


### PR DESCRIPTION
**Description:** Fix to the catalog-info.yaml file added by https://github.com/openedx/completion/pull/287

cf https://github.com/openedx/edx-submissions/pull/234

**Testing instructions:** N/A

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped - N/A
- [x] Changelog record added - N/A
- [x] Documentation updated (not only docstrings) - N/A
- [x] Commits are squashed

**Post merge:**
- [x] Create a tag  - N/A
- [x] Check new version is pushed to PyPi after tag-triggered build is finished.  - N/A
- [ ] Delete working branch (if not needed anymore)
