### PR TITLE
build: adds ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-24.04]
         python-version: ['3.8', '3.11', '3.12']
         toxenv: [quality, django42-drf314, django42-drflatest]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04]
+        os: [ubuntu-20.04, ubuntu-latest]
         python-version: ['3.8', '3.11', '3.12']
         toxenv: [quality, django42-drf314, django42-drflatest]
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

Adds `ubuntu-24.04` to the list of OS used to run CI.

For pypi-publish, replaced  `ubuntu-20.04` with ` `ubuntu-24.04`.

## Supporting Information

Closes https://github.com/openedx/completion/issues/312

## Testing

Tests passing here should be enough to merge this change, and a successful release to pypi will test the rest.

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x]<strike>Version bumped</strike> N/A
- [x] <strike>Changelog record added</strike> N/A
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)