### PR TITLE
docs: Add PII annotations

### DIFF
--- a/completion/models.py
+++ b/completion/models.py
@@ -204,6 +204,8 @@ class BlockCompletion(TimeStampedModel, models.Model):
     calculations are performed on this float, though current practice is to
     only track binary completion, where 1.0 indicates that the block is
     complete, and 0.0 indicates that the block is incomplete.
+
+    .. no_pii:
     """
     id = BigAutoField(primary_key=True)  # pylint: disable=invalid-name
     user = models.ForeignKey(User, on_delete=models.CASCADE)


### PR DESCRIPTION
Per OEP-30, PII annotations should live with their models. I'm just moving this annotation to its proper home and away from the edx-platform safelist.