### PR TITLE
docs: update edx.rtd links to docs.openedx.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Enabling in the LMS
 
 By default, the Open edX LMS does not use this library. To turn it on, go to http://your.lms.site/admin/waffle/switch/, and add a new switch with Name ``completion.enable_completion_tracking`` and Active selected.
 
-See `Completion Tool <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/completion.html>`_ in the Open edX documentation for details on what will happen once enabled.
+See `Completion Tool <https://docs.openedx.org/en/latest/educators/references/course_development/exercise_tools/completion.html>`_ in the Open edX documentation for details on what will happen once enabled.
 
 Getting Started with Development
 ********************************

--- a/docs/internationalization.rst
+++ b/docs/internationalization.rst
@@ -8,7 +8,7 @@ this choice.
 
 Follow the `internationalization coding guidelines`_ in the edX Developer's Guide when developing new features.
 
-.. _internationalization coding guidelines: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/internationalization/i18n.html
+.. _internationalization coding guidelines: https://docs.openedx.org/en/latest/developers/references/developer_guide/internationalization/i18n.html
 
 Updating Translations
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We've moved docs to docs.openedx.org so update the URLs.
