### PR TITLE
feat!: rm user foreign key in db

### DIFF
--- a/completion/migrations/0004_rm_user_db_foreign_key.py
+++ b/completion/migrations/0004_rm_user_db_foreign_key.py
@@ -1,0 +1,21 @@
+# Dont create User foreign key constraint in db to avoid locking up the user table during course completion updates.
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('completion', '0003_learning_context'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='blockcompletion',
+            name='user',
+            field=models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/completion/models.py
+++ b/completion/models.py
@@ -208,7 +208,7 @@ class BlockCompletion(TimeStampedModel, models.Model):
     .. no_pii:
     """
     id = BigAutoField(primary_key=True)  # pylint: disable=invalid-name
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, db_constraint=False)
     context_key = LearningContextKeyField(max_length=255, db_column="course_key")
 
     # note: this usage key may not have the run filled in for


### PR DESCRIPTION
# Description

Inspired by the courseware student module's good performance.
https://github.com/openedx/openedx-platform/blob/b1b59ddc5a7d8af31091c74d1f3b75ff38acde3e/lms/djangoapps/courseware/models.py#L95

1. Context & Architecture
The Completion tracking service is responsible for logging student progress as they navigate and finish multiple blocks within courses. Historically, the database schema for the completion model included a strict, database-level Foreign Key (FK) constraint tied directly to the core User table.

2. The Problem: High-Traffic Lock Contention
Under standard traffic loads, this schema functions as expected. However, during high-traffic spikes—such as thousands of students concurrently engaging with course material—this strict constraint becomes a severe architectural bottleneck.

When a relational database (e.g., MySQL/InnoDB or PostgreSQL) executes an INSERT or UPDATE on a table with a Foreign Key constraint, it must guarantee referential integrity. To do this safely in a highly concurrent environment, the database engine acquires a shared lock (e.g., SELECT ... FOR SHARE) on the referenced row in the parent table—in this case, the User table.

Because the User table is a highly central entity, it is frequently accessed, updated, and locked by various other domains and models across the application. When a massive influx of completion events occurs simultaneously:

The database queues these concurrent transactions, waiting for locks on the User table to be released.

This lock contention causes a dramatic spike in transaction latency, slowing down all INSERT and UPDATE operations linked to the User table.

Prolonged transactions tie up database connection pools and increase the risk of cascading timeouts and deadlocks.

3. The Solution
This PR resolves the bottleneck by removing the explicit database-level foreign key constraint between the Completion model and the User table (e.g., utilizing db_constraint=False in the Django ORM).

While the application code will still conceptually treat this field as a relationship (storing the user_id), the underlying database will no longer enforce the strict referential integrity check on every write operation.

4. Impact & Benefits
Massively Increased Write Throughput: Inserts and updates to the completion logs are now isolated from the User table's lock state. They can execute independently and immediately.

Eliminated Contention Bottleneck: By bypassing the shared locks on the User table, we free up database resources, dramatically reducing transaction times and connection queueing.

Improved System Resilience: The platform can now handle massive traffic spikes and concurrent block completions without degrading the performance of the core User table or the application as a whole.


Inspired in https://github.com/nelc/completion/pull/2

## test
clone 
run
`./manage.py lms migrate completion`
<img width="875" height="909" alt="2026-06-05_15-53" src="https://github.com/user-attachments/assets/b39302cb-ddce-42b7-aabd-b264d0761089" />

Results in production instance


### Before
<img width="876" height="802" alt="2026-06-05_16-52" src="https://github.com/user-attachments/assets/3edd5ff0-5768-412d-ab1e-fd5b8b926274" />

<img width="1571" height="168" alt="image" src="https://github.com/user-attachments/assets/84e2640f-1403-4222-9c84-4fdf007d26e8" />
<img width="554" height="313" alt="image" src="https://github.com/user-attachments/assets/e20a83e0-1241-48a5-a2d2-2523c82febee" />

### After
<img width="854" height="796" alt="2026-06-05_16-58" src="https://github.com/user-attachments/assets/e709b254-3197-4ba1-aaf9-fa41cb669ebe" />


<img width="1740" height="561" alt="image" src="https://github.com/user-attachments/assets/2969ca9d-272f-4f17-920d-0097831da5c8" />

<img width="545" height="232" alt="image" src="https://github.com/user-attachments/assets/191502c3-e2db-4fea-a9a0-91e6a374ec4c" />


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is finished.
- [ ] Delete working branch (if not needed anymore)
